### PR TITLE
Use validation rule, expect 422 for validation failure

### DIFF
--- a/resources/js/vat-validation.js
+++ b/resources/js/vat-validation.js
@@ -2,7 +2,6 @@ import { useThrottleFn, useMemoize } from '@vueuse/core'
 import { token } from 'Vendor/rapidez/core/resources/js/stores/useUser'
 import { mask } from 'Vendor/rapidez/core/resources/js/stores/useMask'
 import { checkVAT, countries } from 'jsvat'
-import { FetchError } from 'Vendor/rapidez/core/resources/js/fetch'
 
 document.addEventListener('vue:loaded', function () {
     window.app.$on('vat-change', async (event) => {
@@ -36,8 +35,6 @@ document.addEventListener('vue:loaded', function () {
         if (result === 'error') {
             return
         }
-
-        console.log(result)
 
         event.target.setCustomValidity(result ? '' : window.config.vat_validation.translations.failed)
         event.target.reportValidity()

--- a/src/Http/Controllers/VatController.php
+++ b/src/Http/Controllers/VatController.php
@@ -2,16 +2,13 @@
 
 namespace Rapidez\VatValidation\Http\Controllers;
 
-use Ibericode\Vat\Validator;
-use Ibericode\Vat\Vies\ViesException;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
+use Rapidez\VatValidation\Rules\VatValid;
 
 class VatController
 {
     /** @return array<string, mixed> */
-    public function __invoke(Request $request): JsonResponse
+    public function __invoke(Request $request): mixed
     {
         $request->validate([
             'id' => 'string|required',
@@ -26,16 +23,10 @@ class VatController
             }
         }
 
-        try {
-            // Try validating the number
-            $validator = new Validator;
-            $result = Cache::remember('vat_' . $request->id, config('rapidez.vatvalidation.cache_duration'), function () use ($request, $validator) {
-                return $validator->validateVatNumber($request->id);
-            });
+        $request->validate([
+            'id' => new VatValid,
+        ]);
 
-            return response()->json($result);
-        } catch (ViesException $exception) {
-            abort(503, $exception->getMessage());
-        }
+        return true;
     }
 }

--- a/src/Rules/VatValid.php
+++ b/src/Rules/VatValid.php
@@ -15,17 +15,13 @@ class VatValid implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        try {
-            $validator = new Validator;
-            $result = Cache::remember('vat_' . $value, config('rapidez.vatvalidation.cache_duration'), function () use ($value, $validator) {
-                return $validator->validateVatNumber($value);
-            });
+        $validator = new Validator;
+        $result = Cache::remember('vat_' . $value, config('rapidez.vatvalidation.cache_duration'), function () use ($value, $validator) {
+            return $validator->validateVatNumber($value);
+        });
 
-            if (!$result) {
-                $fail('Vat validation failed.');
-            }
-        } catch (ViesException $exception) {
-            $fail($exception->getMessage());
+        if (!$result) {
+            $fail('Vat validation failed.');
         }
     }
 }

--- a/src/Rules/VatValid.php
+++ b/src/Rules/VatValid.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rapidez\VatValidation\Rules;
+
+use Closure;
+use Ibericode\Vat\Validator;
+use Ibericode\Vat\Vies\ViesException;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Cache;
+
+class VatValid implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        try {
+            // Try validating the number
+            $validator = new Validator;
+            $result = Cache::remember('vat_' . $value, config('rapidez.vatvalidation.cache_duration'), function () use ($value, $validator) {
+                return $validator->validateVatNumber($value);
+            });
+
+            if (!$result) {
+                $fail('Vat validation failed.');
+            }
+        } catch (ViesException $exception) {
+            $fail($exception->getMessage());
+        }
+    }
+}

--- a/src/Rules/VatValid.php
+++ b/src/Rules/VatValid.php
@@ -16,7 +16,6 @@ class VatValid implements ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         try {
-            // Try validating the number
             $validator = new Validator;
             $result = Cache::remember('vat_' . $value, config('rapidez.vatvalidation.cache_duration'), function () use ($value, $validator) {
                 return $validator->validateVatNumber($value);


### PR DESCRIPTION
Use the default Laravel rule validation for internal consistency as outlined by @indykoning in the initial PR.

I'm still unsure whether or not we want to have the core throw a more specific error (like a `ValidationError` instead of a `FetchError`) when it's a 422 so that we can catch that instead and not have to check the magic number 422, I personally think it would make this type of code nicer.