### PR TITLE
Use vue directive instead of adding the event manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,17 @@ composer require rapidez/vat-validation
 Every Rapidez package will work with this package out of the box, and will not require any configuration.
 
 However, if you're using your own fields, you can add the VAT check to an input by adding this to the input:
+
 ```
-v-on:change="window.app.$emit('vat-change', $event)"
+v-validate.vat
 ```
+
+> [!NOTE]
+> If you're adding validation as an attribute onto a blade component, you will have to do something like this instead:
+> ```
+> v-validate.vat="true"
+> ```
+> This is because the Laravel blade formatter will automatically turn it into `v-validate.vat="v-validate.vat"` if you don't specify an expression.
 
 ## VIES validation
 

--- a/resources/js/directives.js
+++ b/resources/js/directives.js
@@ -1,9 +1,10 @@
 import validateElementVAT from './vat-validation'
+import { useEventListener } from '@vueuse/core'
 
 Vue.directive('validate', {
     bind(el, binding) {
         if ('vat' in binding.modifiers) {
-            el.addEventListener('change', (event) => validateElementVAT(event.target))
+            useEventListener(el, 'change', (event) => validateElementVAT(event.target))
             validateElementVAT(el)
         }
     }

--- a/resources/js/directives.js
+++ b/resources/js/directives.js
@@ -1,0 +1,10 @@
+import validateElementVAT from './vat-validation'
+
+Vue.directive('validate', {
+    bind(el, binding) {
+        if ('vat' in binding.modifiers) {
+            el.addEventListener('change', (event) => validateElementVAT(event.target))
+            validateElementVAT(el)
+        }
+    }
+})

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -1,1 +1,1 @@
-(() => import('./vat-validation.js'))()
+(() => import('./directives.js'))()

--- a/resources/js/vat-validation.js
+++ b/resources/js/vat-validation.js
@@ -57,50 +57,43 @@ const validate = useMemoize(useThrottleFn(
     true,
 ))
 
-function init () {
-    window.app.$on('vat-change', async (event) => {
-        let cleanVatid = event.target.value.replace(/[\s\.-]/g, '')
+export default async (el) => {
+    let cleanVatid = el.value.replace(/[\s\.-]/g, '')
 
-        if(event.target.value != cleanVatid) {
-            event.target.value = cleanVatid
+    if(el.value != cleanVatid) {
+        el.value = cleanVatid
 
-            // Set field and call `change` event to tell Vue
-            // This event unfortunately also calls this function again, so we return here to avoid a double request
-            event.target.dispatchEvent(new Event('change'))
-            return
-        }
+        // Set field and call `change` event to tell Vue
+        // This event unfortunately also calls this function again, so we return here to avoid a double request
+        el.dispatchEvent(new Event('change'))
+        return
+    }
 
-        event.target.setCustomValidity('')
+    el.setCustomValidity('')
 
-        if (!event.target.checkValidity()) {
-            return
-        }
+    if (!el.checkValidity()) {
+        return
+    }
 
-        if (!cleanVatid || cleanVatid.length == 0) {
-            return
-        }
+    if (!cleanVatid || cleanVatid.length == 0) {
+        return
+    }
 
-        if (preValidate(cleanVatid) === false) {
-            event.target.setCustomValidity(window.config.vat_validation.translations.invalid)
-            return
-        }
+    if (preValidate(cleanVatid) === false) {
+        el.setCustomValidity(window.config.vat_validation.translations.invalid)
+        return
+    }
 
-        if (!isViesCheckable(cleanVatid)) {
-            // If we can't check it by VIES then we just assume it's valid.
-            return
-        }
+    if (!isViesCheckable(cleanVatid)) {
+        // If we can't check it by VIES then we just assume it's valid.
+        return
+    }
 
-        let result = await validate(cleanVatid)
-        if (result === 'error') {
-            return
-        }
+    let result = await validate(cleanVatid)
+    if (result === 'error') {
+        return
+    }
 
-        event.target.setCustomValidity(result ? '' : window.config.vat_validation.translations.failed)
-        event.target.reportValidity()
-    });
-}
-
-document.addEventListener('vue:loaded', init)
-if (window.app) {
-    init()
+    el.setCustomValidity(result ? '' : window.config.vat_validation.translations.failed)
+    el.reportValidity()
 }

--- a/resources/js/vat-validation.js
+++ b/resources/js/vat-validation.js
@@ -92,9 +92,6 @@ export default async (el) => {
     if (!cleanVatid || cleanVatid.length == 0) {
         return
     }
-    if (!cleanVatid || cleanVatid.length == 0) {
-        return
-    }
 
     if (preValidate(cleanVatid) === false) {
         el.setCustomValidity(window.config.vat_validation.translations.invalid)
@@ -114,11 +111,7 @@ export default async (el) => {
     if (result === 'error') {
         return
     }
-    let result = await validate(cleanVatid)
-    if (result === 'error') {
-        return
-    }
 
-    el.setCustomValidity(result ? '' : window.config.vat_validation.translations.failed)
+    el.setCustomValidity(result.message ?? '')
     el.reportValidity()
 }


### PR DESCRIPTION
This is a breaking change because all of the Rapidez templates will have to be updated. It's probably a good idea to add some version constraints for this.

There are two reasons for me choosing this approach:
- We may be looking at turning this package into a more generalized validation package
- The previous approach did not re-validate on refresh. So, if you put in an invalid VAT number and then refresh, the number would stay but the invalid state of the input would not. By using a directive we can run the function on bind when we also add the event listener.