### PR TITLE
[3.x] Double check that $on exists

### DIFF
--- a/resources/js/vat-validation.js
+++ b/resources/js/vat-validation.js
@@ -101,6 +101,6 @@ function init () {
 }
 
 document.addEventListener('vue:loaded', init)
-if (window.app) {
+if (window.app && window.app.$on) {
     init()
 }


### PR DESCRIPTION
Apparently, it's possible that `window.app` exists but `window.app.$on` doesn't because Vue hasn't fully initialized yet. This is fine, as the `vue:loaded` will catch the initialization anyway, but it will throw an error in the console.

I've updated the check here to make sure this can't throw an error.