### PR TITLE
[4.x] Return custom validation error when used

### DIFF
--- a/resources/js/vat-validation.js
+++ b/resources/js/vat-validation.js
@@ -58,7 +58,7 @@ const validate = useMemoize(useThrottleFn(
             .catch((error) => {
                 if (FetchError.prototype.isPrototypeOf(error)) {
                     if (error.response.status === 422) {
-                        return false
+                        return error.response.json() ?? { message: window.config.vat_validation.translations.failed }
                     }
                 }
 
@@ -112,7 +112,7 @@ function init () {
             return
         }
 
-        event.target.setCustomValidity(result ? '' : window.config.vat_validation.translations.failed)
+        event.target.setCustomValidity(result.message ?? '')
         event.target.reportValidity()
     });
 }


### PR DESCRIPTION
Ref: GT-2330

There may be cases where we want to use a custom validation error, for example this can be achieved when using the newly added customizable validation rules. This should then be shown on the frontend. However, this is currently not the case.

This PR changes this behavior and shows the custom error message on the frontend.