### PR TITLE
[5.x] Fix certain race conditions

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -1,1 +1,1 @@
-(() => import('./directives.js'))()
+import './directives.js'

--- a/resources/js/vat-validation.js
+++ b/resources/js/vat-validation.js
@@ -79,7 +79,7 @@ export default async (el) => {
 
         // Set field and call `change` event to tell Vue
         // This event unfortunately also calls this function again, so we return here to avoid a double request
-        el.dispatchEvent(new Event('change'))
+        setTimeout(() => el.dispatchEvent(new Event('change')))
         return
     }
 
@@ -103,7 +103,7 @@ export default async (el) => {
         if (shouldForceValidate(cleanVatid)) {
             el.setCustomValidity(window.config.vat_validation.translations.invalid)
         }
-        
+
         return
     }
 


### PR DESCRIPTION
ref: AN-444

Under certain circumstances, this package would get lazy-loaded in too late (after the `vue:loaded` event has been emitted) which caused the directive to not register. Unfortunately, including this into the bundle adds ~20kB of bundle size because of the jsvat package.

I also noticed that sometimes the textbox would not update correctly after the vat id got cleaned up by this package. By adding a setTimeout around the event I was no longer able to reproduce this.